### PR TITLE
Resolved issue #1 by updating the dev_env.ps1 to reflect the changed repo files

### DIFF
--- a/dev_env.ps1
+++ b/dev_env.ps1
@@ -327,7 +327,7 @@ Write-Output " ----------------------------------------------------------------"
 Write-Output ""
 Remove-Item $strDownloadDir -Force -Recurse
 
-$additionalPIPSoftware = @("pyOpenSSL","boto","libnacl")
+$additionalPIPSoftware = @("pyOpenSSL","boto")
 
 Foreach ($pipSoftware in $additionalPIPSoftware) {
     Write-Output "Installing additional requirement [$pipSoftware] via pip install"


### PR DESCRIPTION
that were made to the windows repository depot without changes to the dev_env.ps1. The repository @url: http

://docs.saltstack.com/downloads/windows-deps/dev_env.ps1 appeared to be updated bit it was using 'localpaths' instead of the downloader to download the file.  The vcredist dependencies (vcredist_x64.exe,vcredist_x64_mvc_update.exe) and the
VCForPython27 were removed.  I added the VCForPython27 back and additional pip libraries that are used by the minion and not present in the dev_env.ps1.  There appears to be a process that is updating the repository and if that process is t
o continue then salt may want to have it commit the new dev_env.ps1 to the repostiory.  Having minion builds break this close to release is probably not wise.
- Commit 2
  Removed the libnacl library I had incorrectly added as a dependency.  The library is for RAET which is not currently deployed to windows.  Thanks @UtahDave, just cause your super awesome.   Thanks @twangboy  for the great dev_env.ps1 and so quickly.
